### PR TITLE
Make builds more replicable.

### DIFF
--- a/get_libwallet_api.sh
+++ b/get_libwallet_api.sh
@@ -16,9 +16,6 @@ if [ ! -d $MONERO_DIR/src ]; then
     git submodule init intense
 fi
 git submodule update --remote
-git -C $MONERO_DIR fetch
-git -C $MONERO_DIR checkout master
-#release-v0.11.0.0
 
 ## get monero core tag
 #get_tag


### PR DESCRIPTION
Rely only on submodule commit reference to correlate gui repo with wallet repo instead of always checking out top-of-master. This assures that identical checkouts of the gui repo will produce binaries based on the same point in the wallet repo.